### PR TITLE
Use SixLabors.ImageSharp.Drawing instead of System.Drawing.Common

### DIFF
--- a/Generator/BillLayout.cs
+++ b/Generator/BillLayout.cs
@@ -7,8 +7,8 @@
 
 using Codecrete.SwissQRBill.Generator.Canvas;
 using System;
-using System.Drawing.Drawing2D;
 using System.Globalization;
+using System.Numerics;
 using System.Resources;
 using System.Text;
 using static Codecrete.SwissQRBill.Generator.Address;
@@ -503,14 +503,11 @@ namespace Codecrete.SwissQRBill.Generator
             double scale = size / 476.0;
             double xOffset = 0.36 * size;
             double yOffset = -1.05 * size;
-            using (Matrix matrix = new Matrix())
-            {
-                matrix.Translate((float)x, (float)y);
-                matrix.Rotate((float)(angle / Math.PI * 180));
-                matrix.Translate(mirrored ? (float)xOffset : (float)-xOffset, (float)yOffset);
-                matrix.Scale(mirrored ? (float)-scale : (float)scale, (float)scale);
-                _graphics.SetTransformation(matrix.OffsetX, matrix.OffsetY, angle, mirrored ? -scale : scale, scale);
-            }
+            var matrix = Matrix3x2.CreateScale(mirrored ? (float)-scale : (float)scale, (float)scale) *
+                         Matrix3x2.CreateTranslation(mirrored ? (float)xOffset : (float)-xOffset, (float)yOffset) *
+                         Matrix3x2.CreateRotation((float)angle) *
+                         Matrix3x2.CreateTranslation((float)x, (float)y);
+            _graphics.SetTransformation(matrix.M31, matrix.M32, angle, mirrored ? -scale : scale, scale);
 
             _graphics.StartPath();
             _graphics.MoveTo(46.48, 126.784);

--- a/Generator/Canvas/AbstractCanvas.cs
+++ b/Generator/Canvas/AbstractCanvas.cs
@@ -23,7 +23,12 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
 
         protected void SetupFontMetrics(string fontFamilyList)
         {
-            FontMetrics = new FontMetrics(fontFamilyList);
+            SetupFontMetrics(fontFamilyList, throwFontFamilyNotFoundException: false);
+        }
+
+        protected void SetupFontMetrics(string fontFamilyList, bool throwFontFamilyNotFoundException)
+        {
+            FontMetrics = new FontMetrics(fontFamilyList, throwFontFamilyNotFoundException);
         }
 
         public virtual void PutTextLines(string[] lines, double x, double y, int fontSize, double leading)

--- a/Generator/Canvas/FontMetrics.cs
+++ b/Generator/Canvas/FontMetrics.cs
@@ -6,7 +6,11 @@
 //
 
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using SixLabors.Fonts;
+using SixLabors.Fonts.Exceptions;
 
 namespace Codecrete.SwissQRBill.Generator.Canvas
 {
@@ -29,10 +33,25 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         /// </para>
         /// </summary>
         /// <param name="fontFamilyList">The font families, separated by comma (syntax as in CSS).</param>
-        public FontMetrics(string fontFamilyList)
+        public FontMetrics(string fontFamilyList) : this(fontFamilyList, throwFontFamilyNotFoundException: false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance for the given list of font families.
+        /// <para>
+        /// If more than one family is specified, the first family is used for metrics.
+        /// </para>
+        /// </summary>
+        /// <param name="fontFamilyList">The font families, separated by comma (syntax as in CSS).</param>
+        /// <param name="throwFontFamilyNotFoundException">
+        /// When <see langword="true"/>, throws an exception if none of the font from <paramref name="fontFamilyList"/> are found in the system fonts.
+        /// This is useful when the font is needed at rendering time, e.g. when rendering to PNG.
+        /// </param>
+        public FontMetrics(string fontFamilyList, bool throwFontFamilyNotFoundException)
         {
             FontFamilyList = fontFamilyList;
-            FirstFontFamily = GetFirstFontFamily(fontFamilyList);
+            (FirstFontFamilyInternal, FirstFontFamily) = GetFirstFontFamily(fontFamilyList, throwFontFamilyNotFoundException);
             string family = FirstFontFamily.ToLowerInvariant();
 
             ushort[] boldCharWidthx20x7F;
@@ -83,6 +102,7 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         {
             FontFamilyList = null;
             FirstFontFamily = null;
+            FirstFontFamilyInternal = null;
             _charWidthx20x7F = charWidthx20x7F;
             _charWidthxA0xFF = charWidthxA0xFF;
             _charDefaultWidth = charDefaultWidth;
@@ -100,6 +120,12 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         /// </summary>
         /// <value>The first font family name.</value>
         public string FirstFontFamily { get; }
+
+        /// <summary>
+        /// Gets the first available font family (from the font family list) or <see langword="null"/> if not found in the system fonts.
+        /// </summary>
+        /// <value>The first available font family or <see langword="null"/> if not found in the system fonts.</value>
+        internal FontFamily FirstFontFamilyInternal { get; }
 
         /// <summary>
         /// Gets the distance between the baseline and the top of tallest letter.
@@ -336,26 +362,27 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
             return width;
         }
 
-        private static string GetFirstFontFamily(string fontFamilyList)
+        private static (FontFamily, string) GetFirstFontFamily(string fontFamilyList, bool throwFontFamilyNotFoundException)
         {
-            int index = fontFamilyList.IndexOf(',');
-            if (index < 0)
+            var fontFamilies = fontFamilyList.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(f => f.Trim(' ', '"')).ToList();
+            foreach (var fontFamily in fontFamilies)
             {
-                return fontFamilyList;
+                if (SystemFonts.Collection.TryFind(fontFamily, out var family))
+                {
+                    return (family, fontFamily);
+                }
             }
 
-            string fontFamily = fontFamilyList.Substring(0, index).Trim();
-            if (fontFamily.StartsWith("\""))
+            if (throwFontFamilyNotFoundException)
             {
-                fontFamily = fontFamily.Substring(1);
+                if (fontFamilies.Count == 1)
+                {
+                    throw new FontFamilyNotFoundException(fontFamilies[0]);
+                }
+                throw new AggregateException(fontFamilies.Select(f => new FontFamilyNotFoundException(f)));
             }
 
-            if (fontFamily.EndsWith(("\"")))
-            {
-                fontFamily = fontFamily.Substring(0, fontFamily.Length - 1);
-            }
-
-            return fontFamily;
+            return (null, fontFamilies[0]);
         }
     }
 }

--- a/Generator/Canvas/PDFCanvas.cs
+++ b/Generator/Canvas/PDFCanvas.cs
@@ -7,8 +7,8 @@
 
 using Codecrete.SwissQRBill.Generator.PDF;
 using System;
-using System.Drawing.Drawing2D;
 using System.IO;
+using System.Numerics;
 
 namespace Codecrete.SwissQRBill.Generator.Canvas
 {
@@ -67,21 +67,10 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
             _contentStream.SaveGraphicsState();
             _hasSavedGraphicsState = true;
 
-            using (Matrix matrix = new Matrix())
-            {
-                matrix.Translate((float)translateX, (float)translateY);
-                if (rotate != 0)
-                {
-                    matrix.Rotate((float)(rotate / Math.PI * 180));
-                }
-
-                if (scaleX != 1 || scaleY != 1)
-                {
-                    matrix.Scale((float)scaleX, (float)scaleY);
-                }
-
-                _contentStream.Transform(matrix);
-            }
+            var matrix = Matrix3x2.CreateScale((float)scaleX, (float)scaleY) *
+                         Matrix3x2.CreateRotation((float)rotate) *
+                         Matrix3x2.CreateTranslation((float)translateX, (float)translateY);
+            _contentStream.Transform(matrix);
         }
 
         private void SetFont(bool isBold, int fontSize)

--- a/Generator/Canvas/PNGCanvas.cs
+++ b/Generator/Canvas/PNGCanvas.cs
@@ -5,13 +5,16 @@
 // https://opensource.org/licenses/MIT
 //
 
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Drawing.Drawing2D;
-using System.Drawing.Imaging;
-using System.Drawing.Text;
 using System.IO;
+using System.Numerics;
+using SixLabors.Fonts;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
 
 namespace Codecrete.SwissQRBill.Generator.Canvas
 {
@@ -24,14 +27,13 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
     /// </remarks>
     public class PNGCanvas : AbstractCanvas, IToByteArray
     {
-        private readonly int _resolution;
+        private static readonly IImageEncoder PngEncoder = new PngEncoder();
+
         private readonly float _coordinateScale;
-        private readonly float _fontScale;
-        private Bitmap _bitmap;
-        private Graphics _graphics;
-        private List<PointF> _pathPoints;
-        private List<byte> _pathTypes;
-        private FontFamily _fontFamily;
+        private readonly Image _image;
+        private readonly DrawingOptions _drawingOptions;
+        private readonly PathBuilder _pathBuilder;
+        private PointF _currentPosition;
 
         /// <summary>
         /// Initializes a new instance of a PNG canvas with the given size, resolution and font family.
@@ -49,33 +51,23 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         public PNGCanvas(double width, double height, int resolution, string fontFamilyList)
         {
             // setup font metrics
-            SetupFontMetrics(fontFamilyList);
-            _fontFamily = new FontFamily(FontMetrics.FirstFontFamily);
+            SetupFontMetrics(fontFamilyList, throwFontFamilyNotFoundException: true);
 
             // create image
-            _resolution = resolution;
             _coordinateScale = (float)(resolution / 25.4);
-            _fontScale = (float)(resolution / 72.0);
             int w = (int)(width * _coordinateScale + 0.5);
             int h = (int)(height * _coordinateScale + 0.5);
-            _bitmap = new Bitmap(w, h);
-            _bitmap.SetResolution(_resolution, _resolution);
+            _image = new Image<Argb32>(w, h, Color.White);
+            _image.Metadata.HorizontalResolution = resolution;
+            _image.Metadata.VerticalResolution = resolution;
 
-            // create graphics context
-            _graphics = Graphics.FromImage(_bitmap);
-
-            // clear background
-            _graphics.FillRectangle(Brushes.White, 0, 0, w, h);
-
-            // enable high quality output
-            _graphics.PixelOffsetMode = PixelOffsetMode.HighQuality;
-            _graphics.SmoothingMode = SmoothingMode.HighQuality;
-            _graphics.TextRenderingHint = TextRenderingHint.AntiAlias;
-
-            // initialize transformation
-            Matrix matrix = new Matrix();
-            matrix.Translate(0, _bitmap.Height);
-            _graphics.Transform = matrix;
+            _drawingOptions = new DrawingOptions
+            {
+                GraphicsOptions = { Antialias = true },
+                ShapeOptions = { IntersectionRule = IntersectionRule.Nonzero },
+                TextOptions = { DpiX = resolution, DpiY = resolution }
+            };
+            _pathBuilder = new PathBuilder();
         }
 
         /// <summary>
@@ -86,12 +78,8 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         /// <returns>The byte array containing the PNG image</returns>
         public byte[] ToByteArray()
         {
-            _graphics.Dispose();
-            _graphics = null;
-
             MemoryStream stream = new MemoryStream();
-            _bitmap.Save(stream, ImageFormat.Png);
-            Close();
+            WriteTo(stream);
             return stream.ToArray();
         }
 
@@ -103,9 +91,7 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         /// <param name="stream">The stream to write to.</param>
         public void WriteTo(Stream stream)
         {
-            _graphics.Dispose();
-            _graphics = null;
-            _bitmap.Save(stream, ImageFormat.Png);
+            _image.Save(stream, PngEncoder);
             Close();
         }
 
@@ -117,29 +103,15 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
         /// <param name="path">The path (file name) to write to.</param>
         public void SaveAs(string path)
         {
-            _graphics.Dispose();
-            _graphics = null;
-            _bitmap.Save(path, ImageFormat.Png);
-            Close();
+            using (var stream = new FileStream(path, FileMode.Create))
+            {
+                WriteTo(stream);
+            }
         }
 
         protected void Close()
         {
-            if (_graphics != null)
-            {
-                _graphics.Dispose();
-                _graphics = null;
-            }
-            if (_bitmap != null)
-            {
-                _bitmap.Dispose();
-                _bitmap = null;
-            }
-            if (_fontFamily != null)
-            {
-                _fontFamily.Dispose();
-                _fontFamily = null;
-            }
+            _image.Dispose();
         }
 
         protected override void Dispose(bool disposing)
@@ -149,38 +121,25 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
 
         public override void SetTransformation(double translateX, double translateY, double rotate, double scaleX, double scaleY)
         {
-            // Our coordinate system extends from the bottom upwards. .NET's system
+            // Our coordinate system extends from the bottom upwards. ImageSharp's system
             // extends from the top downwards. So Y coordinates need to be treated specially.
             translateX *= _coordinateScale;
             translateY *= _coordinateScale;
 
-            Matrix matrix = new Matrix();
-            matrix.Translate((float)translateX, _bitmap.Height - (float)translateY);
-            if (rotate != 0)
-            {
-                matrix.Rotate((float)(-rotate / Math.PI * 180));
-            }
-
-            if (scaleX != 1 || scaleY != 1)
-            {
-                matrix.Scale((float)scaleX, (float)scaleY);
-            }
-
-            _graphics.Transform = matrix;
+            var transform = Matrix3x2.CreateScale((float)scaleX, (float)scaleY) *
+                            Matrix3x2.CreateRotation((float)-rotate) *
+                            Matrix3x2.CreateTranslation((float)translateX, _image.Height - (float)translateY);
+            _drawingOptions.Transform = transform;
         }
 
         public override void StartPath()
         {
-            _pathPoints = new List<PointF>();
-            _pathTypes = new List<byte>();
+            _pathBuilder.StartFigure();
         }
 
         public override void CloseSubpath()
         {
-            int lastIndex = _pathTypes.Count - 1;
-            byte pathType = _pathTypes[lastIndex];
-            pathType |= (byte)PathPointType.CloseSubpath;
-            _pathTypes[lastIndex] = pathType;
+            _pathBuilder.CloseFigure();
         }
 
         public override void MoveTo(double x, double y)
@@ -188,8 +147,8 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
             x *= _coordinateScale;
             y *= -_coordinateScale;
 
-            _pathPoints.Add(new PointF((float)x, (float)y));
-            _pathTypes.Add((byte)PathPointType.Start);
+            _pathBuilder.StartFigure();
+            _currentPosition = new PointF((float)x, (float)y);
         }
 
         public override void LineTo(double x, double y)
@@ -197,8 +156,9 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
             x *= _coordinateScale;
             y *= -_coordinateScale;
 
-            _pathPoints.Add(new PointF((float)x, (float)y));
-            _pathTypes.Add((byte)PathPointType.Line);
+            var end = new PointF((float)x, (float)y);
+            _pathBuilder.AddLine(_currentPosition, end);
+            _currentPosition = end;
         }
 
         public override void AddRectangle(double x, double y, double width, double height)
@@ -208,16 +168,21 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
             width *= _coordinateScale;
             height *= -_coordinateScale;
 
-            _pathPoints.Add(new PointF((float)x, (float)y));
-            _pathTypes.Add((byte)PathPointType.Start);
-            _pathPoints.Add(new PointF((float)(x + width), (float)y));
-            _pathTypes.Add((byte)PathPointType.Line);
-            _pathPoints.Add(new PointF((float)(x + width), (float)(y + height)));
-            _pathTypes.Add((byte)PathPointType.Line);
-            _pathPoints.Add(new PointF((float)x, (float)(y + height)));
-            _pathTypes.Add((byte)PathPointType.Line);
-            _pathPoints.Add(new PointF((float)x, (float)y));
-            _pathTypes.Add((byte)PathPointType.Line | (byte)PathPointType.CloseSubpath);
+            var left = (float)x;
+            var right = (float)(x + width);
+            var top = (float)y;
+            var bottom = (float)(y + height);
+            var leftTop = new PointF(left, top);
+            var leftBottom = new PointF(left, bottom);
+            var rightTop = new PointF(right, top);
+            var rightBottom = new PointF(right, bottom);
+            _pathBuilder.StartFigure();
+            _pathBuilder.AddLine(leftTop, rightTop);
+            _pathBuilder.AddLine(rightTop, rightBottom);
+            _pathBuilder.AddLine(rightBottom, leftBottom);
+            _pathBuilder.AddLine(leftBottom, leftTop);
+            _pathBuilder.CloseFigure();
+            _currentPosition = leftTop;
         }
 
         public override void CubicCurveTo(double x1, double y1, double x2, double y2, double x, double y)
@@ -229,21 +194,19 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
             x *= _coordinateScale;
             y *= -_coordinateScale;
 
-            _pathPoints.Add(new PointF((float)x1, (float)y1));
-            _pathTypes.Add((byte)PathPointType.Bezier);
-            _pathPoints.Add(new PointF((float)x2, (float)y2));
-            _pathTypes.Add((byte)PathPointType.Bezier);
-            _pathPoints.Add(new PointF((float)x, (float)y));
-            _pathTypes.Add((byte)PathPointType.Bezier);
+            var start = new PointF((float)x1, (float)y1);
+            var control = new PointF((float)x, (float)y);
+            var end = new PointF((float)x2, (float)y2);
+            _pathBuilder.AddBezier(startPoint: start, controlPoint: control, endPoint: end);
+            _currentPosition = end;
         }
 
         public override void FillPath(int color)
         {
-            using (SolidBrush brush = new SolidBrush(Color.FromArgb(color - 16777216)))
-            using (GraphicsPath path = new GraphicsPath(_pathPoints.ToArray(), _pathTypes.ToArray(), FillMode.Winding))
-            {
-                _graphics.FillPath(brush, path);
-            }
+            var path = _pathBuilder.Build();
+            _pathBuilder.Reset();
+            var rgba = new Rgba32((uint)color) { A = byte.MaxValue };
+            _image.Mutate(b => b.Fill(_drawingOptions, rgba, path));
         }
 
         public override void StrokePath(double strokeWidth, int color)
@@ -253,44 +216,38 @@ namespace Codecrete.SwissQRBill.Generator.Canvas
 
         public override void StrokePath(double strokeWidth, int color, LineStyle lineStyle)
         {
-            float width = (float)strokeWidth * _fontScale;
-
-            using (Pen pen = new Pen(Color.FromArgb(color - 16777216), width))
+            var scale = _drawingOptions.TextOptions.DpiX / 72.0f;
+            var rgba = new Rgba32((uint)color) { A = byte.MaxValue };
+            IPath path;
+            IPen pen;
+            switch (lineStyle)
             {
-                switch (lineStyle)
-                {
-                    case LineStyle.Dashed:
-                        pen.DashPattern = new float[] { 4, 4 };
-                        break;
-                    case LineStyle.Dotted:
-                        pen.StartCap = LineCap.Round;
-                        pen.EndCap = LineCap.Round;
-                        pen.DashCap = DashCap.Round;
-                        pen.DashPattern = new float[] { 0.01f, 2 };
-                        break;
-                    default:
-                        break;
-                }
-
-                using (GraphicsPath path = new GraphicsPath(_pathPoints.ToArray(), _pathTypes.ToArray()))
-                {
-                    _graphics.DrawPath(pen, path);
-                }
+                case LineStyle.Dashed:
+                    path = _pathBuilder.Build();
+                    pen = new Pen(rgba, (float)strokeWidth * scale, new[] { 4f, 4f });
+                    break;
+                case LineStyle.Dotted:
+                    path = _pathBuilder.Build().GenerateOutline(1f, new[] { 0.01f * scale, 3f * scale }, false, JointStyle.Square, EndCapStyle.Round);
+                    pen = new Pen(rgba, (float)strokeWidth * scale);
+                    break;
+                default:
+                    path = _pathBuilder.Build();
+                    pen = new Pen(rgba, (float)strokeWidth * scale);
+                    break;
             }
+            _pathBuilder.Reset();
+            _image.Mutate(b => b.Draw(_drawingOptions, pen, path));
         }
 
         public override void PutText(string text, double x, double y, int fontSize, bool isBold)
         {
-            FontStyle style = isBold ? FontStyle.Bold : FontStyle.Regular;
-            using (Font font = new Font(_fontFamily, fontSize * _fontScale, style, GraphicsUnit.Pixel))
-            {
-                float ascent = _fontFamily.GetCellAscent(style) / 2048.0f * fontSize * _fontScale;
-                x *= _coordinateScale;
-                y *= -_coordinateScale;
-                y -= ascent;
+            x *= _coordinateScale;
+            y *= -_coordinateScale;
 
-                _graphics.DrawString(text, font, Brushes.Black, (float)x, (float)y, StringFormat.GenericTypographic);
-            }
+            var font = new Font(FontMetrics.FirstFontFamilyInternal, fontSize, isBold ? FontStyle.Bold : FontStyle.Regular);
+            float ascent = font.Ascender / 2048.0f * fontSize * _drawingOptions.TextOptions.DpiY / 72.0f;
+            var position = new Vector2((float)x, (float)y - ascent);
+            _image.Mutate(b => b.DrawText(_drawingOptions, text, font, Color.Black, position));
         }
     }
 }

--- a/Generator/Generator.csproj
+++ b/Generator/Generator.csproj
@@ -39,7 +39,7 @@ The Swiss QR bill library:
 
   <ItemGroup>
     <PackageReference Include="Net.Codecrete.QrCodeGenerator" Version="1.6.1" />
-    <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta13" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
   </ItemGroup>
 

--- a/Generator/PDF/ContentStream.cs
+++ b/Generator/PDF/ContentStream.cs
@@ -5,9 +5,9 @@
 // https://opensource.org/licenses/MIT
 //
 
-using System.Drawing.Drawing2D;
 using System.IO;
 using System.IO.Compression;
+using System.Numerics;
 using static System.FormattableString;
 
 namespace Codecrete.SwissQRBill.Generator.PDF
@@ -43,12 +43,14 @@ namespace Codecrete.SwissQRBill.Generator.PDF
             WriteOperator("Q");
         }
 
-        public void Transform(Matrix matrix)
+        public void Transform(Matrix3x2 matrix)
         {
-            foreach (float f in matrix.Elements)
-            {
-                WriteOperand(f);
-            }
+            WriteOperand(matrix.M11);
+            WriteOperand(matrix.M12);
+            WriteOperand(matrix.M21);
+            WriteOperand(matrix.M22);
+            WriteOperand(matrix.M31);
+            WriteOperand(matrix.M32);
 
             WriteOperator("cm");
         }

--- a/GeneratorTest/CleanupTest.cs
+++ b/GeneratorTest/CleanupTest.cs
@@ -19,17 +19,20 @@ namespace Codecrete.SwissQRBill.GeneratorTest
         public void ClosePngFreesResources()
         {
             Type type = typeof(PNGCanvas);
-            FieldInfo bitmapField = type.GetField("_bitmap", BindingFlags.NonPublic | BindingFlags.Instance);
-            Assert.NotNull(bitmapField);
+            FieldInfo imageField = type.GetField("_image", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(imageField);
 
-            PNGCanvas pngCanvas;
+            object image;
+            FieldInfo isDisposedField;
             using (PNGCanvas canvas = new PNGCanvas(QRBill.QrBillWidth, QRBill.QrBillHeight, 300, "Arial"))
             {
-                pngCanvas = canvas;
-                Assert.NotNull(bitmapField.GetValue(pngCanvas));
+                image = imageField.GetValue(canvas);
+                Assert.NotNull(image);
+                isDisposedField = image.GetType().GetField("isDisposed", BindingFlags.NonPublic | BindingFlags.Instance);
+                Assert.NotNull(isDisposedField);
+                Assert.False((bool)isDisposedField.GetValue(image)!);
             }
-
-            Assert.Null(bitmapField.GetValue(pngCanvas));
+            Assert.True((bool)isDisposedField.GetValue(image)!);
         }
     }
 }

--- a/GeneratorTest/VerifyTest.cs
+++ b/GeneratorTest/VerifyTest.cs
@@ -38,7 +38,7 @@ namespace Codecrete.SwissQRBill.GeneratorTest
             using var imgReceived = new MagickImage(received, MagickFormat.Png);
             using var imgVerified = new MagickImage(verified, MagickFormat.Png);
             var diff = imgReceived.Compare(imgVerified, ErrorMetric.PerceptualHash);
-            const double threshold = 0.02;
+            const double threshold = 0.01;
             var compare = diff < threshold;
             if (compare)
             {


### PR DESCRIPTION
Using Assert.Equal on byte arrays is fine as long as the tests pass. As soon as one test fails, it becomes unusable because of its useless message:
> Xunit.Sdk.EqualException
> Assert.Equal() Failure
> Expected: Byte[] [37, 80, 68, 70, 45, ...]
> Actual:   Byte[] [37, 80, 68, 70, 45, ...]

Something has changed in the way compression works in .NET Core 2 and .NET Core 3 and all PDF tests were failing because of the byte-by-byte comparison of PDF files.

Using Verify.ImageMagick instead is much better as it performs a real image comparison (with ImageMagick under the hood).